### PR TITLE
Add conversation_type field to requisition application progress query

### DIFF
--- a/scripts/metabase/requisition-application-progress.sql
+++ b/scripts/metabase/requisition-application-progress.sql
@@ -1,9 +1,7 @@
-/*
- * Metabase Model: Requisition Application Progress
- * URL: https://innosource.metabaseapp.com/model/305-requisition-application-progress
- * Description: Applications with related Requisitions, and their progression through the hiring process.
- */
-
+-- -------------------------------------------------------------------------------------------
+-- Requisition Application Progress
+-- -------------------------------------------------------------------------------------------
+-- METABASE URL: https://innosource.metabaseapp.com/model/305-requisition-application-progress
 with reqs as (
   select
     c.id as client_id,
@@ -42,6 +40,7 @@ with reqs as (
 )
 ,req_applicants as (select ra.*
                          , jr.score as jakib_score
+                         , jr.conversation_type
                          , rs.resume_only_score
                          , jr.created_at as score_created_at
                          , rs.created_at as resume_only_score_created_at
@@ -233,6 +232,7 @@ final as (
     ra.first_name || ' ' || ra.last_name as applicant_name,
     ra.email,
     ra.jakib_score,
+    ra.conversation_type,
     ra.resume_only_score,
     case
         	when ra.jakib_score > 86 or ra.resume_only_score > 81  then 'GREEN'


### PR DESCRIPTION
## Summary
- Added `conversation_type` field from `jakib_results` table to the requisition application progress Metabase query

## Changes Made
- Modified `req_applicants` CTE to include `jr.conversation_type` 
- Added `conversation_type` to the final SELECT output
- Field is now available for reporting and analysis in Metabase

## Test plan
- [ ] Verify query runs successfully in Metabase
- [ ] Confirm conversation_type field appears in results
- [ ] Check that existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)